### PR TITLE
Use collection state for daily crawl source

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -11,6 +11,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.List;
 
 public class Main {
@@ -76,7 +78,7 @@ public class Main {
         try {
             MysqlDao mysqlDao = new MysqlDao();
             // (3) 取出视频列表
-            List<Long> allVideoIdList = mysqlDao.getAllVideoIdList();
+            List<Long> allVideoIdList = mysqlDao.getDailyCollectionVideoIdList(shouldIncludeSundayOnlyDailyCollection());
 
             // (4) 全量获取动态数据
             TodayDynamicDataJob todayDynamicDataJob = new TodayDynamicDataJob(allVideoIdList);
@@ -110,7 +112,7 @@ public class Main {
             mysqlDao.insertStatic(videoStaticDOList);
 
             // (3) 取出视频列表
-            List<Long> allVideoIdList = mysqlDao.getAllVideoIdList();
+            List<Long> allVideoIdList = mysqlDao.getDailyCollectionVideoIdList(shouldIncludeSundayOnlyDailyCollection());
 
             // (4) 全量获取动态数据
             TodayDynamicDataJob todayDynamicDataJob = new TodayDynamicDataJob(allVideoIdList);
@@ -132,5 +134,9 @@ public class Main {
         } catch (Exception e) {
             logger.error(e);
         }
+    }
+
+    private static boolean shouldIncludeSundayOnlyDailyCollection() {
+        return LocalDate.now().getDayOfWeek() == DayOfWeek.SUNDAY;
     }
 }

--- a/src/main/java/dao/MysqlDao.java
+++ b/src/main/java/dao/MysqlDao.java
@@ -108,6 +108,64 @@ public class MysqlDao {
     }
 
     /**
+     * 获取每日动态采集的视频AV号列表
+     *
+     * @return 每日动态采集的视频AV号列表
+     */
+    public List<Long> getDailyCollectionVideoIdList(boolean includeSundayOnly) throws SQLException {
+        List<Long> videoIdList = new ArrayList<>();
+        int count = getDailyCollectionVideoCount(includeSundayOnly);
+        int pageCount = (count + QUERY_SIZE - 1) / QUERY_SIZE;
+        String sql = "SELECT `aid` FROM video_collection_state " +
+                "WHERE (`priority` BETWEEN 1 AND 720 OR `priority` = 0 OR (? AND `priority` = -2)) " +
+                "ORDER BY CASE " +
+                "WHEN `priority` BETWEEN 1 AND 720 THEN 0 " +
+                "WHEN `priority` = 0 THEN 1 " +
+                "WHEN `priority` = -2 THEN 2 " +
+                "ELSE 3 END, `priority`, `aid` " +
+                "LIMIT ?, ?;";
+
+        for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+            int offset = pageIndex * QUERY_SIZE;
+
+            try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+                preparedStatement.setBoolean(1, includeSundayOnly);
+                preparedStatement.setInt(2, offset);
+                preparedStatement.setInt(3, QUERY_SIZE);
+
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    while (resultSet.next()) {
+                        videoIdList.add(resultSet.getLong("aid"));
+                    }
+                }
+            }
+        }
+        return videoIdList;
+    }
+
+    /**
+     * 获取每日动态采集的视频数量
+     *
+     * @return 每日动态采集的视频数量
+     */
+    private int getDailyCollectionVideoCount(boolean includeSundayOnly) throws SQLException {
+        String sql = "SELECT COUNT(*) AS count FROM video_collection_state " +
+                "WHERE (`priority` BETWEEN 1 AND 720 OR `priority` = 0 OR (? AND `priority` = -2));";
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setBoolean(1, includeSundayOnly);
+
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                int count = 0;
+                if (resultSet.next()) {
+                    count = resultSet.getInt("count");
+                }
+                logger.info("Successfully query count of rows from video_collection_state for daily collection. count: {}", count);
+                return count;
+            }
+        }
+    }
+
+    /**
      * 获取当前正在观测的视频列表
      *
      * @param priority 优先度


### PR DESCRIPTION
## Summary
- source daily dynamic crawl IDs from `video_collection_state` instead of `video_static`
- preserve the requested priority order: `1..720`, then `0`, then Sunday-only `-2`
- exclude disabled `-1` and invalid priorities; include `-2` only on Sunday daily runs

## Baseline and compatibility notes
- This repo has no `main` ref; `origin/HEAD` points to `origin/master`, so this PR targets `master`.
- `hantang-dynamic` currently defines `video_collection_state` as the adaptive-minute state table. It is not currently the dynamic crawler's input table; daily refreshes it from daily samples, and minute scheduling uses it to enqueue and update minute tasks.

## Verification
- `git diff --check HEAD~1 HEAD -- src/main/java/Main.java src/main/java/dao/MysqlDao.java`
- Reviewer pass: no blocking issues after the Sunday-only `-2` fix

## Not run
- Maven compile/test: `mvn` is not available on this machine, and the repo does not include `mvnw`.