### PR TITLE
Stream daily dynamic inserts

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,9 +3,7 @@ import business.HantangMinuteJob;
 import business.TodayDynamicDataJob;
 import business.TodayStaticDataJob;
 import dao.MysqlDao;
-import dos.VideoDynamicDO;
 import dos.VideoStaticDO;
-import enums.DynamicInsertTableEnum;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,14 +78,13 @@ public class Main {
 
             // (4) 全量获取动态数据
             TodayDynamicDataJob todayDynamicDataJob = new TodayDynamicDataJob(allVideoIdList);
-            todayDynamicDataJob.getData();
-            List<VideoDynamicDO> videoDynamicDOList = todayDynamicDataJob.getAllVideoDynamicDOList();
-
-            // (5) 全量插入动态数据
-            mysqlDao.insertDynamic(videoDynamicDOList, DynamicInsertTableEnum.DAILY);
+            int failedInsertCount = todayDynamicDataJob.getDataAndInsert(mysqlDao);
 
             // (6) 分区信息
             mysqlDao.insertUserDim(todayDynamicDataJob.getUserDOList());
+            if (failedInsertCount > 0) {
+                logger.error("Some daily dynamic batches failed to insert. failedInsertCount: {}", failedInsertCount);
+            }
         } catch (SQLException e) {
             logger.error("SQLException (normalDynamicTask): {}", String.valueOf(e));
         } catch (Exception e) {
@@ -114,15 +111,14 @@ public class Main {
 
             // (4) 全量获取动态数据
             TodayDynamicDataJob todayDynamicDataJob = new TodayDynamicDataJob(allVideoIdList);
-            todayDynamicDataJob.getData();
-            List<VideoDynamicDO> videoDynamicDOList = todayDynamicDataJob.getAllVideoDynamicDOList();
-
-            // (5) 全量插入动态数据
-            mysqlDao.insertDynamic(videoDynamicDOList, DynamicInsertTableEnum.DAILY);
+            int failedInsertCount = todayDynamicDataJob.getDataAndInsert(mysqlDao);
 
             // (6) 插入用户和分区信息
             mysqlDao.insertTypeDim(todayStaticDataJob.getTypeDOList());
             mysqlDao.insertUserDim(todayDynamicDataJob.getUserDOList());
+            if (failedInsertCount > 0) {
+                logger.error("Some daily dynamic batches failed to insert. failedInsertCount: {}", failedInsertCount);
+            }
         } catch (SQLException e) {
             logger.error("SQLException: {}", String.valueOf(e));
         } catch (IOException e) {

--- a/src/main/java/business/TodayDynamicDataJob.java
+++ b/src/main/java/business/TodayDynamicDataJob.java
@@ -1,6 +1,7 @@
 package business;
 
 import api.BilibiliApi;
+import dao.MysqlDao;
 import dos.UserDO;
 import dos.VideoDynamicDO;
 import org.apache.logging.log4j.LogManager;
@@ -8,10 +9,15 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -94,6 +100,94 @@ public class TodayDynamicDataJob {
         logger.info("Successfully finish all processes for getting dynamic data. Count of processes: {}", futures.size());
         // 关闭线程池
         executorService.shutdown();
+    }
+
+    /**
+     * 并发地调用API获取结果，并在每个批次完成后立即写入每日动态表。
+     */
+    public int getDataAndInsert(MysqlDao mysqlDao) throws IOException {
+        BilibiliApi bilibiliApi = new BilibiliApi();
+        ExecutorService executorService = Executors.newFixedThreadPool(EXECUTORS_SIZE);
+        CompletionService<List<VideoDynamicDO>> completionService = new ExecutorCompletionService<>(executorService);
+        int groupCount = (allVideoIdList.size() + GROUP_SIZE - 1) / GROUP_SIZE;
+        int submittedCount = 0;
+        int failedInsertCount = 0;
+        int insertBatchSize = MysqlDao.getInsertBatchSize();
+        List<VideoDynamicDO> pendingInsertList = new ArrayList<>(insertBatchSize);
+        String recordDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+
+        try {
+            // 分组并发发起请求
+            for (int groupIndex = 0; groupIndex < groupCount; groupIndex++) {
+                int start = groupIndex * GROUP_SIZE;
+                int end = Math.min(start + GROUP_SIZE, allVideoIdList.size());
+                List<Long> sublist = allVideoIdList.subList(start, end);
+                logger.debug("Start process for getting dynamic data from {} to {}", start, end);
+                completionService.submit(() -> bilibiliApi.getVideoInfo(sublist));
+                submittedCount++;
+            }
+
+            // 按完成顺序收集并写入结果，避免等待所有批次结束后再落库。
+            for (int completedCount = 0; completedCount < submittedCount; completedCount++) {
+                try {
+                    List<VideoDynamicDO> videoDynamicDOList = completionService.take().get();
+                    allVideoDynamicDOList.addAll(videoDynamicDOList);
+                    pendingInsertList.addAll(videoDynamicDOList);
+                    failedInsertCount += flushReadyDailyDynamicBatches(
+                            mysqlDao,
+                            pendingInsertList,
+                            recordDate,
+                            insertBatchSize
+                    );
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.error("Interrupted while fetching video dynamic data.", e);
+                    break;
+                } catch (ExecutionException e) {
+                    logger.error("Error occurred while fetching video info.", e);
+                }
+            }
+            failedInsertCount += flushDailyDynamicBatch(mysqlDao, pendingInsertList, recordDate);
+
+            logger.info("Successfully finish all processes for getting and inserting dynamic data. Count of processes: {}", submittedCount);
+            return failedInsertCount;
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    private int flushReadyDailyDynamicBatches(
+            MysqlDao mysqlDao,
+            List<VideoDynamicDO> pendingInsertList,
+            String recordDate,
+            int insertBatchSize
+    ) {
+        int failedInsertCount = 0;
+        while (pendingInsertList.size() >= insertBatchSize) {
+            List<VideoDynamicDO> batch = new ArrayList<>(pendingInsertList.subList(0, insertBatchSize));
+            pendingInsertList.subList(0, insertBatchSize).clear();
+            failedInsertCount += flushDailyDynamicBatch(mysqlDao, batch, recordDate);
+        }
+        return failedInsertCount;
+    }
+
+    private int flushDailyDynamicBatch(
+            MysqlDao mysqlDao,
+            List<VideoDynamicDO> videoDynamicDOList,
+            String recordDate
+    ) {
+        if (videoDynamicDOList.isEmpty()) {
+            return 0;
+        }
+        try {
+            mysqlDao.insertDailyDynamic(videoDynamicDOList, recordDate);
+            videoDynamicDOList.clear();
+            return 0;
+        } catch (SQLException e) {
+            logger.error("Error occurred while inserting video dynamic batch.", e);
+            videoDynamicDOList.clear();
+            return 1;
+        }
     }
 
     public List<VideoDynamicDO> getAllVideoDynamicDOList() {

--- a/src/main/java/dao/MysqlDao.java
+++ b/src/main/java/dao/MysqlDao.java
@@ -49,6 +49,10 @@ public class MysqlDao {
      */
     private static final int QUERY_SIZE = 10000;
 
+    public static int getInsertBatchSize() {
+        return INSERT_SIZE;
+    }
+
     public MysqlDao() throws SQLException, ClassNotFoundException {
         Class.forName("com.mysql.cj.jdbc.Driver");
 
@@ -216,21 +220,33 @@ public class MysqlDao {
      *
      * @param videoDynamicDOList 视频静态信息列表
      */
+    public void insertDailyDynamic(List<VideoDynamicDO> videoDynamicDOList, String recordDate) throws SQLException {
+        insertDynamic(videoDynamicDOList, DynamicInsertTableEnum.DAILY, recordDate, (int) (System.currentTimeMillis() / 1000L));
+    }
+
     public void insertDynamic(List<VideoDynamicDO> videoDynamicDOList, DynamicInsertTableEnum tableEnum) throws SQLException {
-        String sql = String.format("INSERT INTO %s (%s, aid, bvid, coin, favorite, danmaku, view, reply, share, `like`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", tableEnum.getTable(), tableEnum.getTimeColumn());
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String today = dateFormat.format(new Date());
         int now = (int) (System.currentTimeMillis() / 1000L);
+        insertDynamic(videoDynamicDOList, tableEnum, today, now);
+    }
 
+    private void insertDynamic(
+            List<VideoDynamicDO> videoDynamicDOList,
+            DynamicInsertTableEnum tableEnum,
+            String recordDate,
+            int recordTime
+    ) throws SQLException {
+        String sql = String.format("INSERT INTO %s (%s, aid, bvid, coin, favorite, danmaku, view, reply, share, `like`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", tableEnum.getTable(), tableEnum.getTimeColumn());
         // 创建PreparedStatement
         try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             int count = 0;
 
             for (VideoDynamicDO video : videoDynamicDOList) {
                 if (DynamicInsertTableEnum.DAILY.equals(tableEnum)) {
-                    preparedStatement.setString(1, today);
+                    preparedStatement.setString(1, recordDate);
                 } else if (DynamicInsertTableEnum.MINUTE.equals(tableEnum)) {
-                    preparedStatement.setInt(1, now);
+                    preparedStatement.setInt(1, recordTime);
                 }
                 preparedStatement.setLong(2, video.aid());
                 preparedStatement.setString(3, video.bvid());
@@ -254,7 +270,7 @@ public class MysqlDao {
 
             // 插入剩余的记录
             preparedStatement.executeBatch();
-            logger.info("Successfully insert into video_daily. rows: {}", videoDynamicDOList.size());
+            logger.info("Successfully insert into {}. rows: {}", tableEnum.getTable(), videoDynamicDOList.size());
         }
     }
 


### PR DESCRIPTION
## Summary
- insert daily dynamic crawl results while API batches are still being collected
- consume completed API futures with \\ExecutorCompletionService\\ without reducing fetch concurrency
- buffer completed rows up to the existing DAO insert batch size before writing, with a final flush for leftovers
- keep user-dim insertion after collection, even if some dynamic batches failed to insert
- keep a fixed daily record date for the whole crawl run

## Notes
- This PR is intentionally separate from #4 and targets \\master\\; it does not include the collection-state video source change.

## Verification
- \\git diff --check HEAD~1 HEAD -- src/main/java/business/TodayDynamicDataJob.java src/main/java/dao/MysqlDao.java src/main/java/Main.java\\
- Reviewer pass: no blocking issues after fixing batch insert failure handling and DB write batching

## Not run
- Maven compile/test: \\mvn\\ is not available on this machine, and the repo does not include \\mvnw\\.